### PR TITLE
allows save access token without userId

### DIFF
--- a/lib/grants/client-credentials.js
+++ b/lib/grants/client-credentials.js
@@ -1,16 +1,15 @@
 
-module.exports = function (Client) {
+module.exports = function () {
 
   var grant = {};
 
+  /**
+   * Since an anonymous user could use a client's token to access a general service.
+   * Should not populate user's information by the client id in the access token.
+   */
 
   grant.getUserFromClient = function (clientId, clientSecret, cb) {
-    var result = function (client) {
-      cb(null, { id: client.userId });
-    };
-
-    Client.findOne({ _id: clientId, secret: clientSecret }).exec()
-      .then(result, cb);
+    return cb(null, {});
   };
 
 

--- a/lib/models/access-token.js
+++ b/lib/models/access-token.js
@@ -3,7 +3,7 @@ module.exports = function (schema, options) {
 
   schema.add({
     clientId: { type: String, required: true },
-    userId: { type: String, required: true },
+    userId: { type: String },
     accessToken: { type: String, unique: true, required: true },
     expires: { type: Date },
     createdAt: { type: Date, default: Date.now }


### PR DESCRIPTION
allows save access token without userId and do not retrieve user’s information by the client id in the access token
